### PR TITLE
Pass bindings to interface-bgp publish_info

### DIFF
--- a/src/layer.yaml
+++ b/src/layer.yaml
@@ -2,7 +2,7 @@ includes:
   - layer:openstack-principle
   - interface:rabbitmq
   - interface:bgp
-#repo: https://github.com/openstack/charm-neutron-dynamic-routing
+repo: https://github.com/openstack-charmers/charm-neutron-dynamic-routing
 options:
   basic:
     use_venv: true

--- a/src/lib/charm/openstack/dragent.py
+++ b/src/lib/charm/openstack/dragent.py
@@ -33,6 +33,9 @@ DRAGENT_CONF = NEUTRON_DIR + "bgp_dragent.ini"
 OPENSTACK_RELEASE_KEY = ('neutron-dynamic-routing-charm.'
                          'openstack-release-version')
 
+SPEAKER_BINDING = 'bgp-speaker'
+PROVIDER_BINDING = 'provider'
+
 
 # select the default release function
 charms_openstack.charm.use_defaults('charm.default-select-release')
@@ -57,14 +60,22 @@ def assess_status():
     DRAgentCharm.singleton.assess_status()
 
 
+def bgp_speaker_bindings():
+    """Speaker bindings for bgp interface
+
+    :return: list of bindings
+    """
+    return [SPEAKER_BINDING]
+
+
 @os_adapters.config_property
 def provider_ip(cls):
-    return ch_ip.get_relation_ip('provider')
+    return ch_ip.get_relation_ip(PROVIDER_BINDING)
 
 
 @os_adapters.config_property
 def speaker_ip(cls):
-    return ch_ip.get_relation_ip('speaker')
+    return ch_ip.get_relation_ip(SPEAKER_BINDING)
 
 
 class TransportURLAdapter(os_adapters.RabbitMQRelationAdapter):

--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -10,8 +10,8 @@ series:
   - bionic
 subordinate: false
 extra-bindings:
+  # Used to specify the OpenStack provider network interface
   provider:
-  speaker:
 requires:
   amqp:
     interface: rabbitmq

--- a/src/reactive/dragent_handlers.py
+++ b/src/reactive/dragent_handlers.py
@@ -45,7 +45,8 @@ def debug():
 @reactive.when('endpoint.bgp-speaker.joined')
 def publish_bgp_info(endpoint):
     endpoint.publish_info(asn=hookenv.config('asn'),
-                          passive=True)
+                          passive=True,
+                          bindings=dragent.bgp_speaker_bindings())
 
 
 @reactive.when('amqp.connected')


### PR DESCRIPTION
The interface-bgp publish_info function now takes in bindings. Pass
the bgp-speaker relationship binding to the interface.